### PR TITLE
Adds support for updating documents that have been loaded using the s…

### DIFF
--- a/ravendb/documents/cache.py
+++ b/ravendb/documents/cache.py
@@ -48,8 +48,20 @@ class cache(object):
         for update in documents:
             ids.append(update["id"])
 
+            updated = False
             for index, item in enumerate(self._cache):
                 if update["id"] in item:
                     self._cache[index]["doc"] = update["doc"]
+                    updated = true
+
+            if not updated:
+                doc = update["doc"]
+                self._cache.append({
+                    "action": "PUT",
+                    "id": update["id"],
+                    "doc": doc,
+                    "metadata": doc["@metadata"]
+                })
+
 
         return ids

--- a/tests/test_when_using_ravenpy_session_for_documents.py
+++ b/tests/test_when_using_ravenpy_session_for_documents.py
@@ -46,7 +46,39 @@ class test_when_using_ravenpy_session_for_documents(test_base.TestCase):
 
         self.assertEqual(len(results), 0)
 
-    def test_it_is_possible_to_update_documents(self):
+    def test_it_is_possible_to_update_stored_documents(self):
+
+        doc = [self.session.createDocument('Test', {
+            "title": "test document"
+        })]
+
+        documentIds = self.session.store(doc)
+
+        results = None
+
+        docId = documentIds[0]
+
+        doc[0]['title'] = "test document update"
+
+        updatedDoc = self.session.createDocument('Test', {
+            "title": "test document update"
+        })
+
+        self.session.update([{
+            "id": docId,
+            "doc": updatedDoc
+        }])
+
+        self.session.save()
+
+        results = None
+        results = self.session.load(documentIds)
+
+        self.assertEqual("test document update", results[0]['title'])
+        self.session.delete(documentIds)
+        self.session.save()
+
+    def test_it_is_possible_to_update_loaded_documents(self):
 
         documentIds = self.session.store([self.session.createDocument('Test', {
             "title": "test document"
@@ -66,11 +98,10 @@ class test_when_using_ravenpy_session_for_documents(test_base.TestCase):
             "id": docId,
             "doc": doc
         }])
+        self.session.save()
 
         results = None
         results = self.session.load(documentIds)
-
-        results[0]['title'] = "test document update"
 
         self.assertEqual("test document update", results[0]['title'])
         self.session.delete(documentIds)


### PR DESCRIPTION
After a question/comment from @kureus, I've added a change to support updating documents that are loaded using the session as well as documents that have been added to the session. I've also added an additional test and removed a line that was causing the existing test to pass falsely. 
